### PR TITLE
修复兼容性运行时崩溃的问题

### DIFF
--- a/HijackMaker/MainWindowVM.cs
+++ b/HijackMaker/MainWindowVM.cs
@@ -117,7 +117,7 @@ namespace HijackMaker
 
 #define EXTERNC extern ""C""
 
-#define FUNCTION EXTERNC void __cdecl
+#define FUNCTION EXTERNC int __cdecl
 
 #define NOP_FUNC {{ \
 	__nop();\
@@ -132,9 +132,9 @@ namespace HijackMaker
 	__nop();\
 	__nop();\
 	__nop();\
-	__inbyte(__COUNTER__);\
+	return __COUNTER__;\
 }}
-//用__inbyte来生成一点不一样的代码，避免被VS自动合并相同函数
+// 用 __COUNTER__ 来生成一点不一样的代码，避免被 VS 自动合并相同函数
 
 #ifdef _WIN64
 	#define PREFIX ""_""


### PR DESCRIPTION
虽然按正常运行流程来说，in 指令绝对不可能被执行，但是有一种特殊情况。

如果给一个程序设置兼容性，比如在 win10 上运行并设置兼容 xp sp3，系统的兼容层会预先把代码跑一边以检查兼容性问题，这时还没来得及替换跳板函数的内存。虽然是检查的性质，但不知为何，系统会真正的把代码跑起来，于是 in 指令就被执行，然后进程就直接崩溃，系统弹出“应用程序无法正常启动(0xc0000096)”。